### PR TITLE
no error threshold anymore in MRI version (repeat if too slow only)

### DIFF
--- a/LGC_Motiv_task/choice_and_perf.m
+++ b/LGC_Motiv_task/choice_and_perf.m
@@ -93,7 +93,7 @@ switch effort_type
         F_threshold = Ep_or_Em_vars.F_threshold;
         F_tolerance = Ep_or_Em_vars.F_tolerance;
 end
- timeRemainingEndTrial_ONOFF = Ep_or_Em_vars.timeRemainingEndTrial_ONOFF;
+timeRemainingEndTrial_ONOFF = Ep_or_Em_vars.timeRemainingEndTrial_ONOFF;
 
 %% initialize onsets
 [onsets.cross,...

--- a/LGC_Motiv_task/choice_task_main.m
+++ b/LGC_Motiv_task/choice_task_main.m
@@ -262,8 +262,12 @@ if IRM == 1 && session_nb > 0
             % for actual task: no display of mapping but consider 3
             % errors as a trial failure
             Ep_or_Em_vars.errorLimits.useOfErrorMapping = false;
-            Ep_or_Em_vars.errorLimits.useOfErrorThreshold = true;
-            Ep_or_Em_vars.errorLimits.errorThreshold = 3;
+            if session_nb == 0
+                Ep_or_Em_vars.errorLimits.useOfErrorThreshold = true;
+                Ep_or_Em_vars.errorLimits.errorThreshold = 20;
+            else
+                Ep_or_Em_vars.errorLimits.useOfErrorThreshold = false;
+            end
         case 'physical'
             Ep_or_Em_vars.MVC = MVC;
             Ep_or_Em_vars.dq = dq;


### PR DESCRIPTION
error threshold should be kept for calibration only